### PR TITLE
Fixes

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"github.com/MarekWojt/gertdns/util"
 	"github.com/raja/argon2pw"
 )
 
@@ -40,7 +41,8 @@ func (selfUser *userRaw) Tidy() (user, error) {
 	// Create a map => faster access times
 	parsedDomains := make(map[string]string)
 	for _, domain := range selfUser.Domains {
-		parsedDomains[domain] = domain
+		parsedDomain := util.ParseDomain(domain)
+		parsedDomains[parsedDomain] = parsedDomain
 	}
 
 	parsedUser := user{

--- a/web/web.go
+++ b/web/web.go
@@ -190,11 +190,13 @@ func authenticatedRequest(request func(ctx *fasthttp.RequestCtx)) func(ctx *fast
 
 		authenticated, err := auth.IsPasswordAuthenticated(authRequest)
 		if err != nil {
+			ctx.WriteString("Internal server error")
 			ctx.SetStatusCode(fasthttp.StatusInternalServerError)
 			return
 		}
 
 		if !authenticated {
+			ctx.WriteString("Authentication failed")
 			ctx.SetStatusCode(fasthttp.StatusForbidden)
 			return
 		}

--- a/web/web.go
+++ b/web/web.go
@@ -148,7 +148,7 @@ func update(ctx *fasthttp.RequestCtx) {
 	}
 
 	if ipv6 != "" {
-		err := dns.UpdateIpv4(domain, ipv4)
+		err := dns.UpdateIpv6(domain, ipv6)
 		if err != nil {
 			ctx.WriteString(err.Error())
 			ctx.SetStatusCode(fasthttp.StatusNotFound)


### PR DESCRIPTION
Fixed:

- missing response text on authentication failure
- missing response text on internal server error
- updating ipv6 via request for updating both ipv4 and ipv6 didn't work, could reset previously set ipv4
- domain list in auth.toml needed "." suffixes